### PR TITLE
Added properties needed for source link to work

### DIFF
--- a/src/SourceMapTools/SourcemapTools.csproj
+++ b/src/SourceMapTools/SourcemapTools.csproj
@@ -3,6 +3,9 @@
 
 	<PropertyGroup>
 		<DocumentationFile>bin\$(Configuration)\$(TargetFramework)\SourcemapTools.xml</DocumentationFile>
+		<!-- SourceLink -->
+		<PublishRepositoryUrl>true</PublishRepositoryUrl>
+		<EmbedUntrackedSources>true</EmbedUntrackedSources>
 	</PropertyGroup>
 	
 	<ItemGroup>


### PR DESCRIPTION
I see that the project contains a reference to the `Microsoft.SourceLink.GitHub` package and a reference to the GitHub repo in the `nuspec` file. This indicates to me that you want to enable source link. I'm pretty sure the two properties in this PR are needed as well for this to work.