### PR TITLE
Fix nuget.org publish on Windows agent

### DIFF
--- a/ci/default.yml
+++ b/ci/default.yml
@@ -99,6 +99,8 @@ stages:
 
     # release: push to nuget.org with `dotnet nuget push`.
     # Requires a secret pipeline variable NUGET_API_KEY (nuget.org API key).
-    - script: dotnet nuget push "$(Build.SourcesDirectory)/.build/nuget/SourceMapTools.*.nupkg" --source "https://api.nuget.org/v3/index.json" --api-key "$(NUGET_API_KEY)" --skip-duplicate
+    # Use the explicit versioned file name: cmd.exe does not expand the '*' glob, and
+    # `dotnet nuget push` does not resolve it from the mixed-separator path on Windows.
+    - script: dotnet nuget push "$(Build.SourcesDirectory)/.build/nuget/SourceMapTools.$(packageVersion).nupkg" --source "https://api.nuget.org/v3/index.json" --api-key "$(NUGET_API_KEY)" --skip-duplicate
       displayName: Publish to Nuget.org
       condition: and(succeeded(), eq(variables['Build.SourceBranchName'], 'release'))


### PR DESCRIPTION
The `release` build (#202) failed at **Publish to Nuget.org**:

```
error: File does not exist (D:\a\1\s/.build/nuget/SourceMapTools.*.nupkg).
```

`cmd.exe` on the Windows agent doesn't expand the `*` glob, and `dotnet nuget push` didn't resolve the wildcard from the mixed-separator path (Seq.App.Teams works because it runs on Linux, where bash expands the glob). The NuGet API key was supplied correctly.

Fix: push the explicit `SourceMapTools.$(packageVersion).nupkg` instead of a wildcard.

After merging, re-run the release publish (PR `master` → `release`); `--skip-duplicate` makes the retry safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)